### PR TITLE
Changed repository ID type

### DIFF
--- a/src/main/java/info/cukes/repositories/ParentRepository.java
+++ b/src/main/java/info/cukes/repositories/ParentRepository.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Repository;
  * Time: 2:34 PM
  */
 @Repository
-public interface ParentRepository extends JpaRepository<Parent, Integer> {
+public interface ParentRepository extends JpaRepository<Parent, Long> {
 
     public Parent findByFirstName(String firstName);
 }


### PR DESCRIPTION
This change will allow you to use the findone with the repo. By the moment with the integer gives an error, because the ids of the classes are longs.
